### PR TITLE
feat: 랭킹 페이지 구현

### DIFF
--- a/@types/ranking.d.ts
+++ b/@types/ranking.d.ts
@@ -1,0 +1,8 @@
+export interface UserRanking {
+  rank: number;
+  totalPoints: number;
+  user: { id: number; username: string };
+  tier: { id: number; name: string; matchTypeDetails: { gender: string; type: string } };
+  club: { id: number; name: string } | null;
+  imageUrl: string | null;
+}

--- a/app/_actions/getCompData.ts
+++ b/app/_actions/getCompData.ts
@@ -9,6 +9,7 @@ export interface ISearchParams {
   type?: string;
   title?: string;
   date?: string;
+  club?: string;
 }
 
 export const getCompData = async (searchParams?: ISearchParams, count?: number) => {

--- a/app/_actions/getMyRanking.ts
+++ b/app/_actions/getMyRanking.ts
@@ -1,0 +1,31 @@
+import { cookies } from 'next/headers';
+import { ISearchParams } from './getCompData';
+
+export const getMyRanking = async (searchParams: ISearchParams) => {
+  const { gender = 'male', type = 'single' } = searchParams;
+  const cookie = cookies();
+  const token = cookie.get('access');
+
+  const params = new URLSearchParams();
+  params.set('gender', gender);
+  params.set('matchType', type);
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/ranking/realtime/myrank/?${params.toString()}`,
+    {
+      credentials: 'include',
+      method: 'GET',
+      headers: {
+        Authorization: token ? `Bearer ${token.value}` : '',
+      },
+      cache: 'no-cache',
+    },
+  );
+  if (!res.ok) {
+    return;
+  }
+
+  const data = await res.json();
+
+  return data;
+};

--- a/app/_actions/getTiers.ts
+++ b/app/_actions/getTiers.ts
@@ -3,6 +3,7 @@ export const getTiers = async () => {
     const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/tiers/all/`, {
       method: 'GET',
       credentials: 'include',
+      next: { revalidate: 3600 },
     });
 
     if (!res.ok) {

--- a/app/_actions/getUserRanking.ts
+++ b/app/_actions/getUserRanking.ts
@@ -3,12 +3,13 @@ import { ISearchParams } from './getCompData';
 
 export const getUserRanking = async (searchParams: ISearchParams, tiers: Tier[]) => {
   const { gender = 'male', type = 'single' } = searchParams;
+
   const filteredTier = tiers.filter(
     ({ matchTypeDetails }) =>
       matchTypeDetails.gender === gender && matchTypeDetails.type === type,
   );
-  const { tier = filteredTier[0].name } = searchParams;
 
+  const { tier = filteredTier[0].name } = searchParams;
   const tierId = filteredTier.find(({ name }) => name === tier)?.id;
 
   try {

--- a/app/_actions/getUserRanking.ts
+++ b/app/_actions/getUserRanking.ts
@@ -1,0 +1,39 @@
+import { Tier } from '@/@types/tier';
+import { ISearchParams } from './getCompData';
+
+export const getUserRanking = async (searchParams: ISearchParams, tiers: Tier[]) => {
+  const { gender = 'male', type = 'single' } = searchParams;
+  const filteredTier = tiers.filter(
+    ({ matchTypeDetails }) =>
+      matchTypeDetails.gender === gender && matchTypeDetails.type === type,
+  );
+  const { tier = filteredTier[0].name } = searchParams;
+
+  const tierId = filteredTier.find(({ name }) => name === tier)?.id;
+
+  try {
+    const params = new URLSearchParams();
+
+    params.set('gender', gender);
+    params.set('type', type);
+    if (tierId) params.set('tier', `${tierId}`);
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/ranking/user/?${params.toString()}`,
+      {
+        method: 'GET',
+        credentials: 'include',
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error('server errors');
+    }
+
+    const data = await res.json();
+
+    return data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import DropdownIcon from '@/app/_asset/icons/dropdown.svg';
 import Navbar from '@/components/module/Navbar/Navbar';
 import RankingInfoCard from '@/components/module/RankingInfoCard/RankingInfoCard';
-import InputModule from '@/components/module/InputModule/InputModule';
 import SearchIcon from '@/app/_asset/icons/search.svg';
 import { RANKING_CATEGORY } from '@/constants/competition';
 import { TabGroup } from '@/components/core/CompNavigation/TapGroup';
@@ -11,6 +10,8 @@ import { ISearchParams } from '../_actions/getCompData';
 import { getTiers } from '../_actions/getTiers';
 import TierFilter from '@/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter';
 import { UserRanking } from '@/@types/ranking';
+import MyRankingCard from '@/components/organism/RankingPage/MyRankingCard';
+import Input from '@/components/core/Input/Input';
 
 const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
   const tiers = await getTiers();
@@ -40,37 +41,25 @@ const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
           variant="round"
         />
       </div>
-      <div className="no-scrollbar flex h-full flex-col gap-[40px] overflow-scroll border-t-[1px] border-gray-30 bg-gray-10 p-[20px]">
-        <div className="flex flex-col gap-[12px]">
-          <div>내 랭킹</div>
-          <div className="flex justify-between gap-[8px] rounded-[8px] border-[1px] border-[#FC5214] px-[16px] py-[12px]">
-            <span className="w-[24px]">5</span>
-            <div className="flex w-[80px] gap-[8px]">
-              <div className="h-[24px] w-[24px] rounded-[99px]  bg-gray-40"></div>
-              <span>김형섭</span>
-            </div>
-            <div className="flex flex-1 justify-end">
-              <span>1,580</span>
-            </div>
-            <div className="flex flex-1 justify-end">
-              <span>라온테니스</span>
-            </div>
-          </div>
+      <div className="no-scrollbar flex w-full flex-1 flex-col gap-[40px] overflow-scroll border-t-[1px] border-gray-30 bg-gray-10 p-[20px]">
+        <div className="flex w-full flex-col gap-[12px]">
+          <div className="text-headline-6">내 랭킹</div>
+          <MyRankingCard />
         </div>
-        <div className="flex flex-col gap-[16px]">
-          <div className="flex flex-col gap-[12px]">
-            <div>전체랭킹</div>
-            <div>
-              <SearchIcon className="relative  left-[12px] top-[30px] z-50 h-[20px] w-[20px] fill-gray-50" />
-              <InputModule
+        <div className="flex w-full flex-col gap-[16px]">
+          <div className="flex w-full flex-col gap-[12px]">
+            <div className="w-full text-headline-6">전체랭킹</div>
+            <div className="relative">
+              <SearchIcon className="absolute left-[12px] top-[13px] z-50 h-[20px] w-[20px] fill-gray-50" />
+              <Input
                 placeholder="남자 단식 선수 검색"
                 className=" border-gray-30 py-[10px] pl-[44px] pr-[12px]"
-              ></InputModule>
+              />
             </div>
           </div>
           <div className="flex gap-[16px]">
             <div className="flex flex-1 flex-col gap-[8px]">
-              <div className="flex flex-row gap-[16px]">
+              <div className="flex gap-[16px]">
                 <TierFilter
                   tiers={tiers}
                   defaultValue={{ gender: 'male', type: 'single' }}
@@ -83,16 +72,16 @@ const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
                   <DropdownIcon width={24} height={24} fill="#787878" />
                 </div>
               </div>
-              <div className="flex items-center justify-between gap-[8px] py-[8px]">
-                <span className="w-[24px] text-body-3 text-gray-80">랭킹</span>
+              <div className="flex items-center justify-between gap-[8px] py-[8px] text-gray-60">
+                <span className="w-[24px] text-body-3">랭킹</span>
                 <div className="flex w-[80px] gap-[8px]">
-                  <span className="text-body-3 text-gray-80">선수</span>
+                  <span className="text-body-3">선수</span>
                 </div>
                 <div className="flex flex-1 justify-end">
-                  <span className="text-body-3 text-gray-80">점수</span>
+                  <span className="text-body-3">점수</span>
                 </div>
                 <div className="flex flex-1 justify-end">
-                  <span className="text-body-3 text-gray-80">소속클럽</span>
+                  <span className="text-body-3">소속클럽</span>
                 </div>
               </div>
               {usersRankingData.map((userRanking, index) => (

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -1,92 +1,36 @@
-import React from 'react';
-import DropdownIcon from '@/app/_asset/icons/dropdown.svg';
+import React, { Suspense } from 'react';
 import Navbar from '@/components/module/Navbar/Navbar';
-import RankingInfoCard from '@/components/module/RankingInfoCard/RankingInfoCard';
-import SearchIcon from '@/app/_asset/icons/search.svg';
-import { RANKING_CATEGORY } from '@/constants/competition';
-import { TabGroup } from '@/components/core/CompNavigation/TapGroup';
-import { getUserRanking } from '../_actions/getUserRanking';
-import { ISearchParams } from '../_actions/getCompData';
+import type { ISearchParams } from '../_actions/getCompData';
 import { getTiers } from '../_actions/getTiers';
-import TierFilter from '@/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter';
-import { UserRanking } from '@/@types/ranking';
 import MyRankingCard from '@/components/organism/RankingPage/MyRankingCard';
-import Input from '@/components/core/Input/Input';
+import type { Tier } from '@/@types/tier';
+import RankingBoard from '@/components/organism/RankingPage/RankingBoard/RankingBoard';
+import { RankingBoardHeader } from '@/components/organism/RankingPage/RankingBoardHeader/RankingBoardHeader';
+import RankingFilters from '@/components/organism/RankingPage/RankingFilters/RankingFilters';
+import RankingHeader from '@/components/organism/RankingPage/RankingHeader/RankingHeader';
+import TotalRankingHeader from '@/components/organism/RankingPage/TotalRankingHeader/TotalRankingHeader';
 
 const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
-  const tiers = await getTiers();
-  const usersRankingData: UserRanking[] = await getUserRanking(searchParams, tiers);
+  const tiers: Tier[] = await getTiers();
 
   return (
     <div className="relative flex h-full w-full flex-col">
-      <div className="flex flex-col gap-[16px] p-[20px]">
-        <div className="flex flex-row gap-[8px]">
-          <div>
-            <h1 className="text-headline-2 text-gray-100">랭킹</h1>
-          </div>
-          <div className="flex gap-[4px] px-[12px] py-[6px]">
-            <select>
-              <option>2024</option>
-              <option>2025</option>
-            </select>
-            <DropdownIcon width={24} height={24} fill="#787878" />
-          </div>
-        </div>
-        <TabGroup
-          path={'/ranking'}
-          items={RANKING_CATEGORY.map((category, index) => ({
-            text: `${category.title}`,
-            option: [{ gender: `${category.gender}` }, { type: `${category.type}` }],
-          }))}
-          variant="round"
-        />
-      </div>
+      <RankingHeader />
       <div className="no-scrollbar flex w-full flex-1 flex-col gap-[40px] overflow-scroll border-t-[1px] border-gray-30 bg-gray-10 p-[20px]">
         <div className="flex w-full flex-col gap-[12px]">
           <div className="text-headline-6">내 랭킹</div>
           <MyRankingCard />
         </div>
         <div className="flex w-full flex-col gap-[16px]">
-          <div className="flex w-full flex-col gap-[12px]">
-            <div className="w-full text-headline-6">전체랭킹</div>
-            <div className="relative">
-              <SearchIcon className="absolute left-[12px] top-[13px] z-50 h-[20px] w-[20px] fill-gray-50" />
-              <Input
-                placeholder="남자 단식 선수 검색"
-                className=" border-gray-30 py-[10px] pl-[44px] pr-[12px]"
-              />
-            </div>
-          </div>
+          <TotalRankingHeader />
           <div className="flex gap-[16px]">
             <div className="flex flex-1 flex-col gap-[8px]">
-              <div className="flex gap-[16px]">
-                <TierFilter
-                  tiers={tiers}
-                  defaultValue={{ gender: 'male', type: 'single' }}
-                />
-                <div className="flex gap-[4px] py-[4px]">
-                  <select>
-                    <option>클럽필터</option>
-                    <option>라온테니스</option>
-                  </select>
-                  <DropdownIcon width={24} height={24} fill="#787878" />
-                </div>
-              </div>
-              <div className="flex items-center justify-between gap-[8px] py-[8px] text-gray-60">
-                <span className="w-[24px] text-body-3">랭킹</span>
-                <div className="flex w-[80px] gap-[8px]">
-                  <span className="text-body-3">선수</span>
-                </div>
-                <div className="flex flex-1 justify-end">
-                  <span className="text-body-3">점수</span>
-                </div>
-                <div className="flex flex-1 justify-end">
-                  <span className="text-body-3">소속클럽</span>
-                </div>
-              </div>
-              {usersRankingData.map((userRanking, index) => (
-                <RankingInfoCard userRanking={userRanking} key={index} />
-              ))}
+              <RankingFilters tiers={tiers} />
+              <RankingBoardHeader />
+              {/* TODO: 스켈레톤 만들기 */}
+              <Suspense fallback={<div>loading...</div>}>
+                <RankingBoard searchParams={searchParams} tiers={tiers} />
+              </Suspense>
             </div>
           </div>
         </div>

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -14,7 +14,7 @@ import { UserRanking } from '@/@types/ranking';
 
 const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
   const tiers = await getTiers();
-  const usersRankingData: UserRanking = await getUserRanking(searchParams, tiers);
+  const usersRankingData: UserRanking[] = await getUserRanking(searchParams, tiers);
 
   return (
     <div className="relative flex h-full w-full flex-col">
@@ -95,8 +95,8 @@ const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
                   <span className="text-body-3 text-gray-80">소속클럽</span>
                 </div>
               </div>
-              {usersRankingData.map((userRanking) => (
-                <RankingInfoCard userRanking={userRanking} />
+              {usersRankingData.map((userRanking, index) => (
+                <RankingInfoCard userRanking={userRanking} key={index} />
               ))}
             </div>
           </div>

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -24,14 +24,10 @@ const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
         <div className="flex w-full flex-col gap-[16px]">
           <TotalRankingHeader />
           <div className="flex gap-[16px]">
-            <div className="flex flex-1 flex-col gap-[8px]">
-              <RankingFilters tiers={tiers} />
-              <RankingBoardHeader />
-              {/* TODO: 스켈레톤 만들기 */}
-              <Suspense fallback={<div>loading...</div>}>
-                <RankingBoard searchParams={searchParams} tiers={tiers} />
-              </Suspense>
-            </div>
+            {/* TODO: 스켈레톤 만들기 */}
+            <Suspense fallback={<div>loading...</div>}>
+              <RankingBoard searchParams={searchParams} tiers={tiers} />
+            </Suspense>
           </div>
         </div>
       </div>

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -4,18 +4,18 @@ import Navbar from '@/components/module/Navbar/Navbar';
 import RankingInfoCard from '@/components/module/RankingInfoCard/RankingInfoCard';
 import InputModule from '@/components/module/InputModule/InputModule';
 import SearchIcon from '@/app/_asset/icons/search.svg';
+import { RANKING_CATEGORY } from '@/constants/competition';
+import { TabGroup } from '@/components/core/CompNavigation/TapGroup';
+import { getUserRanking } from '../_actions/getUserRanking';
+import { ISearchParams } from '../_actions/getCompData';
+import { getTiers } from '../_actions/getTiers';
+import TierFilter from '@/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter';
+import { UserRanking } from '@/@types/ranking';
 
-const COMP_CATEGORY = [
-  { key: 1, title: '전체' },
-  { key: 2, title: '남자 단식' },
-  { key: 3, title: '여자 단식' },
-  { key: 4, title: '남자 복식' },
-  { key: 5, title: '여자 복식' },
-  { key: 6, title: '혼성 복식' },
-  { key: 7, title: '팀' },
-];
+const page = async ({ searchParams }: { searchParams: ISearchParams }) => {
+  const tiers = await getTiers();
+  const usersRankingData: UserRanking = await getUserRanking(searchParams, tiers);
 
-const page = () => {
   return (
     <div className="relative flex h-full w-full flex-col">
       <div className="flex flex-col gap-[16px] p-[20px]">
@@ -31,16 +31,14 @@ const page = () => {
             <DropdownIcon width={24} height={24} fill="#787878" />
           </div>
         </div>
-        <div className="no-scrollbar flex gap-[8px] overflow-scroll">
-          {COMP_CATEGORY.map((item) => (
-            <div
-              key={item.key}
-              className="items-center justify-center whitespace-nowrap rounded-[99px] bg-gray-20 px-[12px] py-[6px] text-body-2 text-gray-80"
-            >
-              {item.title}
-            </div>
-          ))}
-        </div>
+        <TabGroup
+          path={'/ranking'}
+          items={RANKING_CATEGORY.map((category, index) => ({
+            text: `${category.title}`,
+            option: [{ gender: `${category.gender}` }, { type: `${category.type}` }],
+          }))}
+          variant="round"
+        />
       </div>
       <div className="no-scrollbar flex h-full flex-col gap-[40px] overflow-scroll border-t-[1px] border-gray-30 bg-gray-10 p-[20px]">
         <div className="flex flex-col gap-[12px]">
@@ -73,13 +71,10 @@ const page = () => {
           <div className="flex gap-[16px]">
             <div className="flex flex-1 flex-col gap-[8px]">
               <div className="flex flex-row gap-[16px]">
-                <div className="flex gap-[4px] py-[4px]">
-                  <select>
-                    <option>국화부</option>
-                    <option>개나리부</option>
-                  </select>
-                  <DropdownIcon width={24} height={24} fill="#787878" />
-                </div>
+                <TierFilter
+                  tiers={tiers}
+                  defaultValue={{ gender: 'male', type: 'single' }}
+                />
                 <div className="flex gap-[4px] py-[4px]">
                   <select>
                     <option>클럽필터</option>
@@ -100,10 +95,9 @@ const page = () => {
                   <span className="text-body-3 text-gray-80">소속클럽</span>
                 </div>
               </div>
-              <RankingInfoCard />
-              <RankingInfoCard />
-              <RankingInfoCard />
-              <RankingInfoCard />
+              {usersRankingData.map((userRanking) => (
+                <RankingInfoCard userRanking={userRanking} />
+              ))}
             </div>
           </div>
         </div>

--- a/components/core/CompNavigation/Tab.tsx
+++ b/components/core/CompNavigation/Tab.tsx
@@ -41,9 +41,10 @@ const TabVariants = cva('flex items-center justify-center', {
 interface TabProps extends VariantProps<typeof TabVariants> {
   path: string;
   item: Item;
+  defaultValue: Item;
 }
 
-export const Tab = ({ path, item, variant }: TabProps) => {
+export const Tab = ({ path, item, variant, defaultValue }: TabProps) => {
   const searchParams = useSearchParams();
   const params = new URLSearchParams(searchParams);
 
@@ -61,7 +62,7 @@ export const Tab = ({ path, item, variant }: TabProps) => {
   let isActive = searchParams.toString().includes(params.toString());
   if (
     keyArr.filter((key: string) => searchParams.has(key)).length === 0 &&
-    item.text === '전체'
+    item.text === defaultValue.text
   ) {
     isActive = true;
   }

--- a/components/core/CompNavigation/Tab.tsx
+++ b/components/core/CompNavigation/Tab.tsx
@@ -58,6 +58,7 @@ export const Tab = ({ path, item, variant, defaultValue }: TabProps) => {
   });
 
   if (params.has('tier')) params.delete('tier');
+  if (params.has('club')) params.delete('club');
 
   let isActive = searchParams.toString().includes(params.toString());
   if (

--- a/components/core/CompNavigation/TapGroup.tsx
+++ b/components/core/CompNavigation/TapGroup.tsx
@@ -19,7 +19,13 @@ export const TabGroup = ({
   return (
     <div className={`no-scrollbar flex w-full gap-[12px] overflow-x-scroll `}>
       {items.map((item, index) => (
-        <Tab key={index} item={item} path={path} variant={variant} />
+        <Tab
+          key={index}
+          item={item}
+          path={path}
+          variant={variant}
+          defaultValue={items[0]}
+        />
       ))}
     </div>
   );

--- a/components/module/RankingInfoCard/RankingInfoCard.tsx
+++ b/components/module/RankingInfoCard/RankingInfoCard.tsx
@@ -2,11 +2,21 @@ import { UserRanking } from '@/@types/ranking';
 import Image from 'next/image';
 import React from 'react';
 import UserIcon from '@/app/_asset/icons/user.svg';
+import { cn } from '@/lib/utils/cn';
 
 const RankingInfoCard = ({ userRanking }: { userRanking: UserRanking }) => {
+  const ranker = userRanking.rank < 4 ? true : false;
+
   return (
-    <div className="flex items-center justify-between gap-[8px] py-[12px]">
-      <span className="w-[24px]">{userRanking.rank}</span>
+    <div className="flex items-center justify-between gap-[8px] py-[12px] text-gray-80">
+      <div
+        className={cn(
+          'w-[24px]',
+          `${ranker ? 'text-[14px] font-[700] leading-[20px] text-primary-60' : 'text-body-2'}`,
+        )}
+      >
+        {userRanking.rank}
+      </div>
       <div className="jutify-center flex w-[80px] items-center gap-[8px]">
         <div className="relative h-[24px] w-[24px] overflow-hidden rounded-full">
           {userRanking.imageUrl == null ? (
@@ -17,13 +27,13 @@ const RankingInfoCard = ({ userRanking }: { userRanking: UserRanking }) => {
             <Image src={userRanking.imageUrl} alt="avatar" fill sizes="24px" />
           )}
         </div>
-        <span>{userRanking.user.username}</span>
+        <div className="text-sub-headline-2">{userRanking.user.username}</div>
       </div>
-      <div className="flex flex-1 justify-end">
-        <span>{userRanking.totalPoints}</span>
+      <div className="flex flex-1 justify-end text-body-2">
+        <div>{userRanking.totalPoints}</div>
       </div>
-      <div className="flex flex-1 justify-end">
-        <span>{userRanking.club ? userRanking.club.name : '무소속'}</span>
+      <div className="flex flex-1 justify-end text-body-2">
+        <div>{userRanking.club ? userRanking.club.name : '무소속'}</div>
       </div>
     </div>
   );

--- a/components/module/RankingInfoCard/RankingInfoCard.tsx
+++ b/components/module/RankingInfoCard/RankingInfoCard.tsx
@@ -1,18 +1,29 @@
+import { UserRanking } from '@/@types/ranking';
+import Image from 'next/image';
 import React from 'react';
+import UserIcon from '@/app/_asset/icons/user.svg';
 
-const RankingInfoCard = () => {
+const RankingInfoCard = ({ userRanking }: { userRanking: UserRanking }) => {
   return (
-    <div className="flex justify-between gap-[8px] py-[12px]">
-      <span className="w-[24px]">5</span>
-      <div className="flex w-[80px] gap-[8px]">
-        <div className="h-[24px] w-[24px] rounded-[99px]  bg-gray-40"></div>
-        <span>김형섭</span>
+    <div className="flex items-center justify-between gap-[8px] py-[12px]">
+      <span className="w-[24px]">{userRanking.rank}</span>
+      <div className="jutify-center flex w-[80px] items-center gap-[8px]">
+        <div className="relative h-[24px] w-[24px] overflow-hidden rounded-full">
+          {userRanking.imageUrl == null ? (
+            <div className="flex h-full w-full items-center justify-center bg-gray-30">
+              <UserIcon className="h-[40%] w-[40%] fill-gray-60" />
+            </div>
+          ) : (
+            <Image src={userRanking.imageUrl} alt="avatar" fill sizes="24px" />
+          )}
+        </div>
+        <span>{userRanking.user.username}</span>
       </div>
       <div className="flex flex-1 justify-end">
-        <span>1,580</span>
+        <span>{userRanking.totalPoints}</span>
       </div>
       <div className="flex flex-1 justify-end">
-        <span>라온테니스</span>
+        <span>{userRanking.club ? userRanking.club.name : '무소속'}</span>
       </div>
     </div>
   );

--- a/components/organism/CompetitionPage/CompetitionHomePage/CompListFilter/CompListFilter.tsx
+++ b/components/organism/CompetitionPage/CompetitionHomePage/CompListFilter/CompListFilter.tsx
@@ -38,7 +38,7 @@ const CompListFilter = ({ filterOption }: CompListFilter) => {
         id={name}
         onChange={handleChange}
         value={searchParams.get(name) ?? ''}
-        className="z-10 w-full appearance-none pr-[24px] outline-none"
+        className="z-10 w-full appearance-none pr-[24px] text-sub-headline-2 text-gray-80 outline-none"
       >
         {options.map((option, index) => (
           <option key={index} value={option.value}>

--- a/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter.tsx
+++ b/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter.tsx
@@ -7,18 +7,17 @@ import DropdownIcon from '@/app/_asset/icons/dropdown.svg';
 
 const TierFilter = ({
   tiers,
-  defaultValue = { gender: 'all', type: 'all' },
+  initialValue = { gender: 'all', type: 'all' },
 }: {
   tiers: Tier[];
-  defaultValue?: { gender: string; type: string };
+  initialValue?: { gender: string; type: string };
 }) => {
-  console.log(defaultValue);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const currentGender = searchParams.get('gender') || defaultValue.gender;
-  const currentType = searchParams.get('type') || defaultValue.type;
+  const currentGender = searchParams.get('gender') || initialValue.gender;
+  const currentType = searchParams.get('type') || initialValue.type;
 
   const filteredTiers = tiers.filter(({ matchTypeDetails: { gender, type } }) => {
     if (currentGender !== 'all' && currentType !== 'all') {
@@ -31,6 +30,8 @@ const TierFilter = ({
     (name: string, value: string) => {
       const params = new URLSearchParams(searchParams.toString());
       params.set(name, value);
+
+      if (searchParams.has('club')) params.delete('club');
 
       return params.toString();
     },
@@ -48,9 +49,9 @@ const TierFilter = ({
         id={'tier'}
         onChange={handleChange}
         value={searchParams.get('tier') ?? ''}
-        className="z-10 w-full appearance-none pr-[24px] outline-none"
+        className="z-10 w-full appearance-none pr-[24px] text-sub-headline-2 text-gray-80 outline-none"
       >
-        {defaultValue.gender === 'all' && <option value="all">전체</option>}
+        {initialValue.gender === 'all' && <option value="all">전체</option>}
         {filteredTiers.map((tier) => (
           <option key={tier.id} value={tier.name}>
             {tier.name}

--- a/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter.tsx
+++ b/components/organism/CompetitionPage/CompetitionHomePage/TierFilter/TierFilter.tsx
@@ -5,13 +5,20 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { ChangeEvent, useCallback } from 'react';
 import DropdownIcon from '@/app/_asset/icons/dropdown.svg';
 
-const TierFilter = ({ tiers }: { tiers: Tier[] }) => {
+const TierFilter = ({
+  tiers,
+  defaultValue = { gender: 'all', type: 'all' },
+}: {
+  tiers: Tier[];
+  defaultValue?: { gender: string; type: string };
+}) => {
+  console.log(defaultValue);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const currentGender = searchParams.get('gender') || 'all';
-  const currentType = searchParams.get('type') || 'all';
+  const currentGender = searchParams.get('gender') || defaultValue.gender;
+  const currentType = searchParams.get('type') || defaultValue.type;
 
   const filteredTiers = tiers.filter(({ matchTypeDetails: { gender, type } }) => {
     if (currentGender !== 'all' && currentType !== 'all') {
@@ -43,7 +50,7 @@ const TierFilter = ({ tiers }: { tiers: Tier[] }) => {
         value={searchParams.get('tier') ?? ''}
         className="z-10 w-full appearance-none pr-[24px] outline-none"
       >
-        <option value="all">전체</option>
+        {defaultValue.gender === 'all' && <option value="all">전체</option>}
         {filteredTiers.map((tier) => (
           <option key={tier.id} value={tier.name}>
             {tier.name}

--- a/components/organism/ProfilePage/UserPage/RecordSection/RecordSection.tsx
+++ b/components/organism/ProfilePage/UserPage/RecordSection/RecordSection.tsx
@@ -4,7 +4,7 @@ import MatchCard from '@/components/organism/CompetitionProgressPage/MatchCard';
 
 const RecordSection = ({ matchData }: { matchData: UserMatches }) => {
   const { name, start, matchTypeDetails, tier, matches } = matchData;
-  console.log(matchData);
+
   return (
     <>
       {matches.length !== 0 && (

--- a/components/organism/RankingPage/MyRankingCard.tsx
+++ b/components/organism/RankingPage/MyRankingCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const MyRankingCard = async () => {
+  return (
+    <div className="flex justify-between gap-[8px] rounded-[8px] border-[1px] border-[#FC5214] px-[16px] py-[12px]">
+      <span className="w-[24px]">5</span>
+      <div className="flex w-[80px] gap-[8px]">
+        <div className="h-[24px] w-[24px] rounded-[99px]  bg-gray-40"></div>
+        <span>김형섭</span>
+      </div>
+      <div className="flex flex-1 justify-end">
+        <span>1,580</span>
+      </div>
+      <div className="flex flex-1 justify-end">
+        <span>라온테니스</span>
+      </div>
+    </div>
+  );
+};
+
+export default MyRankingCard;

--- a/components/organism/RankingPage/RankingBoard/RankingBoard.tsx
+++ b/components/organism/RankingPage/RankingBoard/RankingBoard.tsx
@@ -1,0 +1,25 @@
+import { UserRanking } from '@/@types/ranking';
+import type { Tier } from '@/@types/tier';
+import type { ISearchParams } from '@/app/_actions/getCompData';
+import { getUserRanking } from '@/app/_actions/getUserRanking';
+import RankingInfoCard from '@/components/module/RankingInfoCard/RankingInfoCard';
+import React from 'react';
+
+const RankingBoard = async ({
+  searchParams,
+  tiers,
+}: {
+  searchParams: ISearchParams;
+  tiers: Tier[];
+}) => {
+  const usersRankingData: UserRanking[] = await getUserRanking(searchParams, tiers);
+  return (
+    <>
+      {usersRankingData.map((userRanking, index) => (
+        <RankingInfoCard userRanking={userRanking} key={index} />
+      ))}
+    </>
+  );
+};
+
+export default RankingBoard;

--- a/components/organism/RankingPage/RankingBoard/RankingBoard.tsx
+++ b/components/organism/RankingPage/RankingBoard/RankingBoard.tsx
@@ -4,6 +4,8 @@ import type { ISearchParams } from '@/app/_actions/getCompData';
 import { getUserRanking } from '@/app/_actions/getUserRanking';
 import RankingInfoCard from '@/components/module/RankingInfoCard/RankingInfoCard';
 import React from 'react';
+import { RankingBoardHeader } from '../RankingBoardHeader/RankingBoardHeader';
+import RankingFilters from '../RankingFilters/RankingFilters';
 
 const RankingBoard = async ({
   searchParams,
@@ -12,13 +14,27 @@ const RankingBoard = async ({
   searchParams: ISearchParams;
   tiers: Tier[];
 }) => {
+  // console.log(searchParams);
+  // console.log(searchParams.club);
   const usersRankingData: UserRanking[] = await getUserRanking(searchParams, tiers);
+  const filteredData: UserRanking[] = usersRankingData.filter((data) => {
+    if (!searchParams.club || searchParams.club === 'all') {
+      return true;
+    }
+    if (searchParams.club === '무소속') {
+      return data.club === null;
+    }
+    return data.club?.name === searchParams.club;
+  });
+  console.log(filteredData);
   return (
-    <>
-      {usersRankingData.map((userRanking, index) => (
+    <div className="flex flex-1 flex-col gap-[8px]">
+      <RankingFilters tiers={tiers} usersRankingData={usersRankingData} />
+      <RankingBoardHeader />
+      {filteredData.map((userRanking, index) => (
         <RankingInfoCard userRanking={userRanking} key={index} />
       ))}
-    </>
+    </div>
   );
 };
 

--- a/components/organism/RankingPage/RankingBoardHeader/RankingBoardHeader.tsx
+++ b/components/organism/RankingPage/RankingBoardHeader/RankingBoardHeader.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const RankingBoardHeader = () => {
+  return (
+    <div className="flex items-center justify-between gap-[8px] py-[8px] text-gray-60">
+      <span className="w-[24px] text-body-3">랭킹</span>
+      <div className="flex w-[80px] gap-[8px]">
+        <span className="text-body-3">선수</span>
+      </div>
+      <div className="flex flex-1 justify-end">
+        <span className="text-body-3">점수</span>
+      </div>
+      <div className="flex flex-1 justify-end">
+        <span className="text-body-3">소속클럽</span>
+      </div>
+    </div>
+  );
+};

--- a/components/organism/RankingPage/RankingFilters/RankingFilters.tsx
+++ b/components/organism/RankingPage/RankingFilters/RankingFilters.tsx
@@ -1,18 +1,70 @@
-import React from 'react';
+'use client';
+import React, { ChangeEvent, useCallback } from 'react';
 import TierFilter from '../../CompetitionPage/CompetitionHomePage/TierFilter/TierFilter';
 import DropdownIcon from '@/app/_asset/icons/dropdown.svg';
 import type { Tier } from '@/@types/tier';
+import { UserRanking } from '@/@types/ranking';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
-const RankingFilters = ({ tiers }: { tiers: Tier[] }) => {
+const RankingFilters = ({
+  tiers,
+  usersRankingData,
+}: {
+  tiers: Tier[];
+  usersRankingData: UserRanking[];
+}) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(name, value);
+
+      return params.toString();
+    },
+    [searchParams],
+  );
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    router.replace(pathname + '?' + createQueryString('club', event.target.value));
+  };
+
+  const clubNameSet = new Set(
+    usersRankingData.map((data) => {
+      if (!data.club) return '무소속';
+      return data.club?.name;
+    }),
+  );
+
+  const clubNameArr = Array.from(clubNameSet).sort((a, b) => a.localeCompare(b, 'ko-KR'));
+
   return (
     <div className="flex gap-[16px]">
-      <TierFilter tiers={tiers} defaultValue={{ gender: 'male', type: 'single' }} />
-      <div className="flex gap-[4px] py-[4px]">
-        <select>
-          <option>클럽필터</option>
-          <option>라온테니스</option>
+      <TierFilter tiers={tiers} initialValue={{ gender: 'male', type: 'single' }} />
+      <div className="relative flex w-[100px]">
+        <select
+          onChange={handleChange}
+          value={searchParams.get('club') ?? ''}
+          className="z-10 w-full appearance-none truncate pr-[24px] text-sub-headline-2 text-gray-80 outline-none"
+        >
+          <option value="" disabled>
+            클럽 필터
+          </option>
+          <option value="all">전체</option>
+          {clubNameArr.map((clubName, index) => (
+            <option key={index} value={clubName}>
+              {clubName}
+            </option>
+          ))}
         </select>
-        <DropdownIcon width={24} height={24} fill="#787878" />
+        <DropdownIcon
+          width={24}
+          height={24}
+          fill="#787878"
+          className="absolute right-0 top-1/2 z-0 -translate-y-1/2"
+        />
       </div>
     </div>
   );

--- a/components/organism/RankingPage/RankingFilters/RankingFilters.tsx
+++ b/components/organism/RankingPage/RankingFilters/RankingFilters.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import TierFilter from '../../CompetitionPage/CompetitionHomePage/TierFilter/TierFilter';
+import DropdownIcon from '@/app/_asset/icons/dropdown.svg';
+import type { Tier } from '@/@types/tier';
+
+const RankingFilters = ({ tiers }: { tiers: Tier[] }) => {
+  return (
+    <div className="flex gap-[16px]">
+      <TierFilter tiers={tiers} defaultValue={{ gender: 'male', type: 'single' }} />
+      <div className="flex gap-[4px] py-[4px]">
+        <select>
+          <option>클럽필터</option>
+          <option>라온테니스</option>
+        </select>
+        <DropdownIcon width={24} height={24} fill="#787878" />
+      </div>
+    </div>
+  );
+};
+
+export default RankingFilters;

--- a/components/organism/RankingPage/RankingHeader/RankingHeader.tsx
+++ b/components/organism/RankingPage/RankingHeader/RankingHeader.tsx
@@ -1,0 +1,32 @@
+import { TabGroup } from '@/components/core/CompNavigation/TapGroup';
+import { RANKING_CATEGORY } from '@/constants/competition';
+import React from 'react';
+
+const RankingHeader = () => {
+  return (
+    <div className="flex flex-col gap-[16px] p-[20px]">
+      <div className="flex flex-row gap-[8px]">
+        <div>
+          <h1 className="text-headline-2 text-gray-100">랭킹</h1>
+        </div>
+        <div className="flex gap-[4px] px-[12px] py-[6px]">
+          <select>
+            <option>2024</option>
+            <option>2025</option>
+          </select>
+          {/* <DropdownIcon width={24} height={24} fill="#787878" /> */}
+        </div>
+      </div>
+      <TabGroup
+        path={'/ranking'}
+        items={RANKING_CATEGORY.map((category, index) => ({
+          text: `${category.title}`,
+          option: [{ gender: `${category.gender}` }, { type: `${category.type}` }],
+        }))}
+        variant="round"
+      />
+    </div>
+  );
+};
+
+export default RankingHeader;

--- a/components/organism/RankingPage/TotalRankingHeader/TotalRankingHeader.tsx
+++ b/components/organism/RankingPage/TotalRankingHeader/TotalRankingHeader.tsx
@@ -1,0 +1,20 @@
+import Input from '@/components/core/Input/Input';
+import React from 'react';
+import SearchIcon from '@/app/_asset/icons/search.svg';
+
+const TotalRankingHeader = () => {
+  return (
+    <div className="flex w-full flex-col gap-[12px]">
+      <div className="w-full text-headline-6">전체랭킹</div>
+      <div className="relative">
+        <SearchIcon className="absolute left-[12px] top-[13px] z-50 h-[20px] w-[20px] fill-gray-50" />
+        <Input
+          placeholder="남자 단식 선수 검색"
+          className=" border-gray-30 py-[10px] pl-[44px] pr-[12px]"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TotalRankingHeader;

--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -22,6 +22,14 @@ export const COMP_CATEGORY: CompCategory[] = [
   { title: '팀', gender: 'team', type: 'team' },
 ];
 
+export const RANKING_CATEGORY: CompCategory[] = [
+  { title: '남자 단식', gender: 'male', type: 'single' },
+  { title: '여자 단식', gender: 'female', type: 'single' },
+  { title: '남자 복식', gender: 'male', type: 'double' },
+  { title: '여자 복식', gender: 'female', type: 'double' },
+  { title: '팀', gender: 'team', type: 'team' },
+];
+
 export const COMP_TIER = {
   name: 'tier',
   options: [


### PR DESCRIPTION
1. [x] 실시간 랭킹 api 연동
2. [x] 젠더,타입 필터링
3. [x] 티어 필터링
4. [ ] 년도별 필터링
5. [ ] 마이랭킹 api 연동(젠더,타입 같이 보내기)
6. [x] 클럽 필터링
7. [ ] 팀 랭킹 api 연동
8. [ ] 이름 검색