### PR TITLE
feat: 유저 프로필 랭킹 추가, competition 타입 리팩토링, 팀 랭킹 데이터 추가

### DIFF
--- a/@types/apply.d.ts
+++ b/@types/apply.d.ts
@@ -1,3 +1,5 @@
+import { MatchTypeDetails } from './competition';
+
 export interface Applicant {
   userName: string;
   userPhone: string;
@@ -12,10 +14,7 @@ export interface ApplicantInfo {
 export interface AppliedCompetition {
   name: string;
   startDate: string;
-  matchTypeDetails: {
-    gender: string;
-    type: string;
-  };
+  matchTypeDetails: MatchTypeDetails;
   tier: string;
   totalRounds: number;
   location: string;

--- a/@types/competition.d.ts
+++ b/@types/competition.d.ts
@@ -1,134 +1,55 @@
+import { GENDER, MATCH_TYPE } from '@/constants/competition';
 import { UserData } from './user';
 
-export interface Competition {
+type CompetitionBase = {
   id: number;
   name: string;
   startDate: string;
-  endData: string;
-  matchTypeDetails: {
-    gender: 'female' | 'male' | 'mix';
-    type: 'single' | 'double' | 'team';
-  };
   tier: string;
+  matchTypeDetails: MatchTypeDetails;
   location: string;
   imageUrl: string;
   status: string;
+};
+
+export type Competition = CompetitionBase & {
   waitingCount: number;
+  endData: string;
   nextMatch?: NextMatchInfo;
-  [key: string]: string | number;
-}
-
-export interface CompetitionProps {
-  compData: Competition | MyCompData;
-}
-
-export type NextMatchInfo = {
-  id: string | null;
-  teammate: [{ id: string; name: string }, { id: string; name: string }];
-  opponent: [{ id: string; name: string }, { id: string; name: string }] | null;
-  court: string | null;
-  round: number;
+  category?: 'before' | 'during' | 'ended';
 };
 
-type ImageType = {
-  src: string;
-  height: number;
-  width: number;
-  blurDataURL: string;
-  blurWidth: number;
-  blurHeight: number;
-};
+CompDetailInfo;
 
-export type CompDetailInfo = {
-  id: number;
-  name: string;
-  startDate: string;
-  tier: string;
-  matchTypeDetails: { gender: string; type: string };
+export type CompetitionDetails = CompetitionBase & {
+  waitingCount: number;
   totalRounds: number;
   totalSets: number;
-  location: string;
   address: string;
   description: string;
   rule: string;
   phone: string;
   siteLink: string;
-  imageUrl: string | null;
-  status: string;
-  waitingCount: number;
 };
 
-interface CompStatusButtonContent {
-  [key: string]: {
-    label: string;
-    variant: 'primary' | 'secondary' | 'tertiary' | 'ghost';
-    size: 'sm' | 'md' | 'lg';
-    colors: 'default' | 'gray';
-    endPoint: string;
-  };
-}
-
-type CompCategory = {
-  title: string;
-  gender?: 'male' | 'female' | 'mix' | 'team' | 'all' | undefined;
-  type?: 'single' | 'double' | 'team' | 'all' | undefined;
-};
-
-export interface Match {
-  id: number;
-  matchRound: number;
-  matchNumber: number;
-  courtNumber: number;
-  totalSets: number;
-  description: string;
-  winnerUser?: UserData[];
-  aTeamUsers?: UserData[];
-  bTeamUsers?: UserData[];
-  sets?: Set[];
-}
-
-export type Set = {
-  id: number;
-  setNumber: number;
-  aScore: number;
-  bScore: number;
-};
-
-export type MyCompData = {
-  id: number;
-  name: string;
-  startDate: string;
-  tier: string;
-  matchTypeDetails: { gender: string; type: string };
+export type MyCompetition = CompetitionBase & {
   totalRounds: number;
   totalSets: number;
-  location: string | null;
   address: string | null;
   description: string;
   rule: string;
   phone: string | null;
   siteLink: string;
-  imageUrl: string | null;
-  status: string;
   applyStatus: string;
   myteam: string[];
   matchStatus: string | null;
   matches: Matches;
 };
 
-export type Matches = {
-  id: number;
-  matchRound: number;
-  matchNumber: number;
-  courtNumber: number;
-  winnerName: string[];
-  opponentUser: string[];
-};
-
 export type CompetitionResult = {
   competition: number;
   competitionName: string;
-  matchTypeDetails: { gender: string; type: string };
+  matchTypeDetails: MatchTypeDetails;
   tier: string;
   winner: number;
   winnerParticipants: {
@@ -143,3 +64,64 @@ export type CompetitionResult = {
     clubName: string | null;
   }[];
 };
+
+export type NextMatchInfo = {
+  id: string | null;
+  teammate: [{ id: string; name: string }, { id: string; name: string }];
+  opponent: [{ id: string; name: string }, { id: string; name: string }] | null;
+  court: string | null;
+  round: number;
+};
+
+type MatchBase = {
+  id: number;
+  matchRound: number;
+  matchNumber: number;
+  courtNumber: number;
+};
+
+export type Matches = MatchBase & {
+  winnerName: string[];
+  opponentUser: string[];
+};
+
+export type Match = MatchBase & {
+  totalSets: number;
+  description: string;
+  winnerUser?: UserData[];
+  aTeamUsers?: UserData[];
+  bTeamUsers?: UserData[];
+  sets?: Set[];
+};
+
+export type Set = {
+  id: number;
+  setNumber: number;
+  aScore: number;
+  bScore: number;
+};
+
+type MatchTypeDetails = {
+  gender: 'female' | 'male' | 'mix';
+  type: 'single' | 'double' | 'team';
+};
+
+export type CompCategory = {
+  title: string;
+  gender?: 'male' | 'female' | 'mix' | 'team' | 'all';
+  type?: 'single' | 'double' | 'team' | 'all';
+};
+
+type CompStatusButtonContentKey = keyof typeof CompStatusButtonContent;
+
+export type CompStatusButtonContentItem = {
+  label: string;
+  variant: 'primary' | 'secondary' | 'tertiary' | 'ghost';
+  size: 'sm' | 'md' | 'lg';
+  colors: 'default' | 'gray';
+  endPoint: string;
+};
+
+export type GenderKey = keyof typeof GENDER;
+
+export type MatchTypeKey = keyof typeof MATCH_TYPE;

--- a/@types/competition.d.ts
+++ b/@types/competition.d.ts
@@ -19,8 +19,6 @@ export type Competition = CompetitionBase & {
   category?: 'before' | 'during' | 'ended';
 };
 
-CompDetailInfo;
-
 export type CompetitionDetails = CompetitionBase & {
   waitingCount: number;
   totalRounds: number;

--- a/@types/competition.d.ts
+++ b/@types/competition.d.ts
@@ -102,8 +102,8 @@ export type Set = {
 };
 
 type MatchTypeDetails = {
-  gender: 'female' | 'male' | 'mix';
-  type: 'single' | 'double' | 'team';
+  gender: GenderKey;
+  type: MatchTypeKey;
 };
 
 export type CompCategory = {

--- a/@types/ranking.d.ts
+++ b/@types/ranking.d.ts
@@ -1,3 +1,5 @@
+import { MatchTypeKey } from './competition';
+
 export type UserRanking = UserRankingWithoutImage & {
   imageUrl: string | null;
 };
@@ -26,7 +28,7 @@ export type Ranking = TeamRanking | UserRanking;
 export type RankingWithoutImage = UserRankingWithoutImage | TeamRankingWithoutImage;
 
 export type MyProfileRanking = {
-  mainRanking: string | null;
+  mainRanking: MatchTypeKey | null;
   single: UserRankingWithoutImage[] | null;
   double: UserRankingWithoutImage[] | null;
   team: TeamRankingWithoutImage[] | null;

--- a/@types/record.d.ts
+++ b/@types/record.d.ts
@@ -1,4 +1,4 @@
-import { Match } from './competition';
+import { Match, MatchTypeDetails } from './competition';
 
 export interface Record {
   id: number;
@@ -9,7 +9,7 @@ export interface Record {
 
 export interface UserMatches {
   name: string;
-  matchTypeDetails: { gender: string; type: string };
+  matchTypeDetails: MatchTypeDetails;
   tier: string;
   start: string;
   matches: Match[];

--- a/@types/team.d.ts
+++ b/@types/team.d.ts
@@ -10,5 +10,10 @@ export type Team = {
 
 export type TennisTeamData = {
   team: Team;
+  teamRanking: {
+    rank: number;
+    totalPoints: number;
+    team: { id: number; name: string };
+  }[];
   users: ClubTeamUser[];
 };

--- a/@types/user.d.ts
+++ b/@types/user.d.ts
@@ -1,4 +1,5 @@
 import { Club } from './club';
+import { GenderKey } from './competition';
 import { ImageFile } from './image';
 import { Team } from './team';
 
@@ -13,7 +14,7 @@ export type UserData = {
   id: number;
   phone: string;
   username: string;
-  gender: string;
+  gender: GenderKey;
   birth: number;
   imageUrl: string | null;
   tiers?:

--- a/@types/user.d.ts
+++ b/@types/user.d.ts
@@ -21,7 +21,7 @@ export type UserData = {
     | {
         id: number;
         name: string;
-        matchTypeDetail: { gender: string; type: string };
+        matchTypeDetail: MatchTypeDetails;
       }[]
     | null;
   club: Club | null;

--- a/app/(profile)/team/[id]/page.tsx
+++ b/app/(profile)/team/[id]/page.tsx
@@ -7,7 +7,7 @@ import type { TennisTeamData } from '@/@types/team';
 import { getTeamData } from '@/app/_actions/getTeamData';
 
 const page = async ({ params }: { params: { id: string } }) => {
-  const { team, users }: TennisTeamData = await getTeamData(params.id);
+  const { team, users, teamRanking }: TennisTeamData = await getTeamData(params.id);
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -20,7 +20,7 @@ const page = async ({ params }: { params: { id: string } }) => {
             imageUrl={team.imageUrl}
             description={team.description}
           />
-          <TeamSection rank={32} win={32} lose={15} />
+          <TeamSection rank={teamRanking[0].rank} win={32} lose={15} />
         </div>
 
         <div className="flex w-full flex-1 flex-col gap-[40px] bg-white p-[20px]">

--- a/app/competition/[id]/apply/page.tsx
+++ b/app/competition/[id]/apply/page.tsx
@@ -2,14 +2,13 @@ import CompInfoCard from '@/components/module/CompInfoCard/CompInfoCard';
 import { ApplyForm } from '@/components/organism/CompetitionPage';
 import React from 'react';
 import type { UserData } from '@/@types/user';
-import type { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 import { getCompDetail } from '@/app/_actions/getCompDetail';
 import { getMyData } from '@/app/_actions/getMyData';
 
 const page = async ({ params }: { params: { id: number } }) => {
-  const [userData, competitionDetailData]: [UserData, CompDetailInfo] = await Promise.all(
-    [getMyData(), getCompDetail(params.id)],
-  );
+  const [userData, competitionDetailData]: [UserData, CompetitionDetails] =
+    await Promise.all([getMyData(), getCompDetail(params.id)]);
 
   return (
     <div className="no-scrollbar flex flex-1 flex-col gap-[8px] overflow-scroll bg-gray-30">

--- a/app/competition/[id]/progress/page.tsx
+++ b/app/competition/[id]/progress/page.tsx
@@ -2,7 +2,7 @@ import HeaderBar from '@/components/core/HeaderBar/HeaderBar';
 import React, { Suspense } from 'react';
 import CompInfoCard from '@/components/organism/CompetitionProgressPage/CompInfoCard';
 import MatchList from '@/components/organism/CompetitionProgressPage/MatchList';
-import type { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 import { getCompDetail } from '@/app/_actions/getCompDetail';
 import { TabGroup } from '@/components/core/CompNavigation/TapGroup';
 import Button from '@/components/core/Button/Button';
@@ -17,7 +17,7 @@ const page = async ({
   params: { id: number };
   searchParams: { roundnumber?: number };
 }) => {
-  const compDetailData: CompDetailInfo = await getCompDetail(params.id);
+  const compDetailData: CompetitionDetails = await getCompDetail(params.id);
 
   function powersOfTwo(totalRounds: number) {
     return Array.from({ length: totalRounds }, (_, i) => Math.pow(2, i));

--- a/app/competition/[id]/result/page.tsx
+++ b/app/competition/[id]/result/page.tsx
@@ -3,7 +3,7 @@ import { getCompResult } from '@/app/_actions/getCompResult';
 import Button from '@/components/core/Button/Button';
 import HeaderBar from '@/components/core/HeaderBar/HeaderBar';
 import ResultCard from '@/components/module/ResultCard/ResultCard';
-import { GENDER, MATCH_TYPE } from '@/constants/competition';
+import { printMatchTypeInfo } from '@/lib/utils/printMatchTypeInfo';
 import Link from 'next/link';
 import React from 'react';
 
@@ -23,8 +23,10 @@ const page = async ({ params }: { params: { id: number } }) => {
 
       <div className="flex w-full flex-col items-start gap-[16px] p-[20px]">
         <div className="text-headline-2">{result.competitionName}</div>
-        <div className="text-sub-headline-2">
-          {GENDER[gender]} {MATCH_TYPE[type]} {tier}
+        <div className="flex gap-[4px] text-sub-headline-2">
+          <div>{printMatchTypeInfo(gender, type)}</div>
+          <div>{'\u00B7'}</div>
+          <div>{tier}</div>
         </div>
       </div>
 

--- a/app/mypage/ranking/[id]/page.tsx
+++ b/app/mypage/ranking/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { GenderKey } from '@/@types/competition';
 import type { MyProfileRanking } from '@/@types/ranking';
 import { ISearchParams } from '@/app/_actions/getCompData';
 import { getUserRanking } from '@/app/_actions/getUserRanking';
@@ -10,7 +11,7 @@ const page = async ({
   searchParams,
 }: {
   params: { id: string };
-  searchParams: { gender: string };
+  searchParams: { gender: GenderKey };
 }) => {
   const myProfileRanking: MyProfileRanking = await getUserRanking(params.id);
 

--- a/components/module/CompCard/CompCard.tsx
+++ b/components/module/CompCard/CompCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import type { Competition, MyCompData } from '@/@types/competition';
+import type { Competition, MyCompetition } from '@/@types/competition';
 import Image from 'next/image';
 import React from 'react';
 import { formatDate } from '@/lib/utils/formatDate';
@@ -13,7 +13,7 @@ const CompCard = ({
   comp,
   status,
 }: {
-  comp: Competition | MyCompData;
+  comp: Competition | MyCompetition;
   status: 'all' | 'my' | 'comp';
 }) => {
   const router = useRouter();
@@ -52,7 +52,7 @@ const CompCard = ({
             </div>
           </div>
         </div>
-        {status === 'my' && <CompCardMatchDetail compData={comp as MyCompData} />}
+        {status === 'my' && <CompCardMatchDetail compData={comp as MyCompetition} />}
 
         {status === 'comp' && <CompStatusButton compData={comp} />}
       </div>

--- a/components/module/CompCard/CompCardMatchDetail/CompCardMatchDetail.tsx
+++ b/components/module/CompCard/CompCardMatchDetail/CompCardMatchDetail.tsx
@@ -1,8 +1,8 @@
 import CompStatusInfo from '../CompStatusInfo/CompStatusInfo';
 import NextMatchInfo from '../NextMatchInfo/NextMatchInfo';
-import type { MyCompData } from '@/@types/competition';
+import type { MyCompetition } from '@/@types/competition';
 
-const CompCardMatchDetail = ({ compData }: { compData: MyCompData }) => {
+const CompCardMatchDetail = ({ compData }: { compData: MyCompetition }) => {
   return (
     <div className="rounded-[8px] bg-gray-20 p-[12px]">
       {compData.status === 'before' && <NextMatchInfo compData={compData} />}

--- a/components/module/CompCard/CompStatusButton/CompStatusButton.tsx
+++ b/components/module/CompCard/CompStatusButton/CompStatusButton.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { Competition, MyCompData } from '@/@types/competition';
+import type { Competition, MyCompetition } from '@/@types/competition';
 import React, { ButtonHTMLAttributes, MouseEvent } from 'react';
 import Button from '@/components/core/Button/Button';
 import { useRouter } from 'next/navigation';
 import { COMP_STATUS_BUTTON_CONTENT } from '@/constants/competition';
 
 interface CompStatusButtonProps {
-  compData: Competition | MyCompData;
+  compData: Competition | MyCompetition;
 }
 
 const CompStatusButton = ({ compData }: CompStatusButtonProps) => {

--- a/components/module/CompCard/CompStatusInfo/CompStatusInfo.tsx
+++ b/components/module/CompCard/CompStatusInfo/CompStatusInfo.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import ChevronRightIcon from '@/app/_asset/icons/chevron-right.svg';
 import FlagIcon from '@/app/_asset/icons/flag.svg';
-import { MyCompData } from '@/@types/competition';
+import type { MyCompetition } from '@/@types/competition';
 import { useRouter } from 'next/navigation';
 
-const CompStatusInfo = ({ compData }: { compData: MyCompData }) => {
+const CompStatusInfo = ({ compData }: { compData: MyCompetition }) => {
   const { totalRounds, matches } = compData;
   let round = `${Math.round(2 ** (totalRounds - matches?.matchRound + 1))}강`;
   if (round == '2강') round = '결승';

--- a/components/module/CompCard/NextMatchInfo/NextMatchInfo.tsx
+++ b/components/module/CompCard/NextMatchInfo/NextMatchInfo.tsx
@@ -6,7 +6,7 @@ const NextMatchInfo = ({ compData }: { compData: MyCompData }) => {
   const { matches, status, applyStatus } = compData;
 
   const beforeText =
-    (applyStatus === 'unpaid' && '참가 대기중') ||
+    (applyStatus === 'unpaid' && '입금 대기중') ||
     (applyStatus === 'confirmed_participation' && !matches && '경기 미배정') ||
     (matches?.courtNumber && `${matches.courtNumber}번 코트`);
 

--- a/components/module/CompCard/NextMatchInfo/NextMatchInfo.tsx
+++ b/components/module/CompCard/NextMatchInfo/NextMatchInfo.tsx
@@ -1,7 +1,7 @@
-import type { Matches, MyCompData } from '@/@types/competition';
+import type { MyCompetition } from '@/@types/competition';
 import React from 'react';
 
-const NextMatchInfo = ({ compData }: { compData: MyCompData }) => {
+const NextMatchInfo = ({ compData }: { compData: MyCompetition }) => {
   const { matches, status, applyStatus } = compData;
 
   const beforeText =

--- a/components/module/CompDetailSection/CompDetailSection.tsx
+++ b/components/module/CompDetailSection/CompDetailSection.tsx
@@ -4,11 +4,11 @@ import {
   CompDetail,
   ImageBanner,
 } from '@/components/organism/CompetitionPage';
-import type { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 import { getCompDetail } from '@/app/_actions/getCompDetail';
 
 const CompDetailSection = async ({ id }: { id: number }) => {
-  const compDetailData: CompDetailInfo = await getCompDetail(id);
+  const compDetailData: CompetitionDetails = await getCompDetail(id);
 
   return (
     <div className="no-scrollbar flex h-full w-full flex-1 flex-col overflow-scroll bg-white">

--- a/components/module/CompInfoCard/CompInfoCard.tsx
+++ b/components/module/CompInfoCard/CompInfoCard.tsx
@@ -3,13 +3,13 @@ import FlagIcon from '@/app/_asset/icons/flag.svg';
 import CalendarIcon from '@/app/_asset/icons/calendar.svg';
 import MapPinIcon from '@/app/_asset/icons/map-pin.svg';
 import MapIcon from '@/app/_asset/icons/map.svg';
-import type { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 import CopyButton from '../../core/CopyButton/CopyButton';
 import { formatDate } from '@/lib/utils/formatDate';
 import type { AppliedCompetition } from '@/@types/apply';
 import { GENDER, MATCH_TYPE } from '@/constants/competition';
 
-const CompInfoCard = ({ data }: { data: CompDetailInfo | AppliedCompetition }) => {
+const CompInfoCard = ({ data }: { data: CompetitionDetails | AppliedCompetition }) => {
   const { startDate, matchTypeDetails, tier, totalRounds, location, address } = data;
 
   return (

--- a/components/module/CompInfoCard/CompInfoCard.tsx
+++ b/components/module/CompInfoCard/CompInfoCard.tsx
@@ -7,7 +7,7 @@ import type { CompetitionDetails } from '@/@types/competition';
 import CopyButton from '../../core/CopyButton/CopyButton';
 import { formatDate } from '@/lib/utils/formatDate';
 import type { AppliedCompetition } from '@/@types/apply';
-import { GENDER, MATCH_TYPE } from '@/constants/competition';
+import { printMatchTypeInfo } from '@/lib/utils/printMatchTypeInfo';
 
 const CompInfoCard = ({ data }: { data: CompetitionDetails | AppliedCompetition }) => {
   const { startDate, matchTypeDetails, tier, totalRounds, location, address } = data;
@@ -23,7 +23,7 @@ const CompInfoCard = ({ data }: { data: CompetitionDetails | AppliedCompetition 
         <span className="flex-1">
           {matchTypeDetails && tier && totalRounds
             ? [
-                `${GENDER[matchTypeDetails.gender]} ${MATCH_TYPE[matchTypeDetails.type]}`,
+                `${printMatchTypeInfo(matchTypeDetails.gender, matchTypeDetails.type)}`,
                 tier,
                 `${Math.pow(2, totalRounds)}강`,
               ].join(' \u00B7 ')

--- a/components/module/MemberProfile/MemberProfile.tsx
+++ b/components/module/MemberProfile/MemberProfile.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import Image from 'next/image';
-import { cn } from '@/lib/utils/cn';
 import Link from 'next/link';
 import UserIcon from '@/app/_asset/icons/user.svg';
 
@@ -8,23 +7,15 @@ interface MemberProfileProps {
   id: number;
   name: string;
   image: string | null;
-  number: number;
   teamName?: string | null;
 }
 
-const MemberProfile: FC<MemberProfileProps> = ({
-  id,
-  name,
-  image,
-  number,
-  teamName = null,
-}) => {
+const MemberProfile: FC<MemberProfileProps> = ({ id, name, image, teamName = null }) => {
   return (
     <Link
       href={`/user/${id}`}
       className="flex items-center gap-[8px] self-stretch py-[12px] text-body-2"
     >
-      <div className={cn('w-[24px] text-headline-7 text-gray-60')}>{number}</div>
       <div className="flex w-[120px] items-center gap-[12px]">
         <div className="relative h-[32px] w-[32px] flex-shrink-0 overflow-hidden rounded-full">
           {/* TODO: 공통 컴포넌트로 만들기 */}
@@ -38,7 +29,6 @@ const MemberProfile: FC<MemberProfileProps> = ({
         </div>
         <div className="text-sub-headline-2">{name}</div>
       </div>
-      <div className="flex-1 text-right">{id}</div>
       <div className="flex-1 text-right">{teamName ? teamName : '-'}</div>
     </Link>
   );

--- a/components/module/MemberSection/MemberSection.tsx
+++ b/components/module/MemberSection/MemberSection.tsx
@@ -6,9 +6,7 @@ const MemberSection = ({ userData }: { userData: ClubTeamUser[] }) => {
   return (
     <>
       <div className="flex w-full items-center gap-[8px] text-body-3 text-gray-60">
-        <div className="w-[24px]">번호</div>
         <div className="flex w-[120px] items-center gap-[12px]">선수</div>
-        <div className="flex-1 text-right">선수 등록 번호</div>
         <div className="flex-1 text-right">소속 팀</div>
       </div>
       <div className="no-scrollbar flex w-full flex-1 flex-col overflow-scroll">
@@ -18,7 +16,6 @@ const MemberSection = ({ userData }: { userData: ClubTeamUser[] }) => {
             id={id}
             image={imageUrl}
             name={username}
-            number={index + 1}
             teamName={team?.name}
           />
         ))}

--- a/components/module/UserProfile/UserHighlightRankingCard/UserHighlightRankingCard.tsx
+++ b/components/module/UserProfile/UserHighlightRankingCard/UserHighlightRankingCard.tsx
@@ -1,8 +1,7 @@
 import type { MyProfileRanking } from '@/@types/ranking';
 import { UserData } from '@/@types/user';
-import { getMyTitleRanking } from '@/app/_actions/getMyTitleRanking';
 import { getUserRanking } from '@/app/_actions/getUserRanking';
-import { GENDER, MATCH_TYPE } from '@/constants/competition';
+import { printMatchTypeInfo } from '@/lib/utils/printMatchTypeInfo';
 import React from 'react';
 
 interface UserHighlightRankingCardProps {
@@ -18,7 +17,7 @@ const UserHighlightRankingCard = async ({ userData }: UserHighlightRankingCardPr
     const titleMatchType =
       mainRanking === 'team'
         ? '팀'
-        : `${GENDER[userData!.gender]} ${MATCH_TYPE[mainRanking!]}`;
+        : `${printMatchTypeInfo(userData!.gender, mainRanking!)}`;
 
     let titleName = '미정';
     if (data && 'team' in data[0]) titleName = data[0].team.name;

--- a/components/organism/CompetitionPage/ApplyPage/ApplyPageSection.tsx
+++ b/components/organism/CompetitionPage/ApplyPage/ApplyPageSection.tsx
@@ -1,4 +1,4 @@
-import { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 import { UserData } from '@/@types/user';
 import { getCompDetail } from '@/app/_actions/getCompDetail';
 import { getMyData } from '@/app/_actions/getMyData';
@@ -7,9 +7,8 @@ import React from 'react';
 import ApplyForm from './ApplyForm/ApplyForm';
 
 const ApplyPageSection = async ({ id }: { id: number }) => {
-  const [userData, competitionDetailData]: [UserData, CompDetailInfo] = await Promise.all(
-    [getMyData(), getCompDetail(id)],
-  );
+  const [userData, competitionDetailData]: [UserData, CompetitionDetails] =
+    await Promise.all([getMyData(), getCompDetail(id)]);
 
   return (
     <>

--- a/components/organism/CompetitionPage/DetailPage/CompDetail/CompDetail.tsx
+++ b/components/organism/CompetitionPage/DetailPage/CompDetail/CompDetail.tsx
@@ -1,11 +1,11 @@
 'use client';
-import React, { Suspense } from 'react';
+import React from 'react';
 import Link from 'next/link';
 import ChevronRightIcon from '@/app/_asset/icons/chevron-right.svg';
 import CompInfoCard from '@/components/module/CompInfoCard/CompInfoCard';
-import type { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 
-const CompDetail = ({ data }: { data: CompDetailInfo }) => {
+const CompDetail = ({ data }: { data: CompetitionDetails }) => {
   return (
     <div className="flex w-full flex-1 flex-col gap-[24px]">
       <div className="flex w-full flex-col gap-[16px]">

--- a/components/organism/CompetitionProgressPage/CompInfoCard.tsx
+++ b/components/organism/CompetitionProgressPage/CompInfoCard.tsx
@@ -1,8 +1,12 @@
-import { CompDetailInfo } from '@/@types/competition';
+import type { CompetitionDetails } from '@/@types/competition';
 import { GENDER, MATCH_TYPE } from '@/constants/competition';
 import React from 'react';
 
-const CompInfoCard = async ({ compDetailData }: { compDetailData: CompDetailInfo }) => {
+const CompInfoCard = async ({
+  compDetailData,
+}: {
+  compDetailData: CompetitionDetails;
+}) => {
   return (
     <div className="flex flex-col gap-[8px] self-stretch">
       <span className="text-headline-2">{compDetailData.name}</span>

--- a/components/organism/CompetitionProgressPage/CompInfoCard.tsx
+++ b/components/organism/CompetitionProgressPage/CompInfoCard.tsx
@@ -1,5 +1,5 @@
 import type { CompetitionDetails } from '@/@types/competition';
-import { GENDER, MATCH_TYPE } from '@/constants/competition';
+import { printMatchTypeInfo } from '@/lib/utils/printMatchTypeInfo';
 import React from 'react';
 
 const CompInfoCard = async ({
@@ -11,8 +11,11 @@ const CompInfoCard = async ({
     <div className="flex flex-col gap-[8px] self-stretch">
       <span className="text-headline-2">{compDetailData.name}</span>
       <span className="text-sub-headline-2 text-gray-80">
-        {GENDER[compDetailData.matchTypeDetails.gender]}{' '}
-        {MATCH_TYPE[compDetailData.matchTypeDetails.type]} · {compDetailData.tier}
+        {printMatchTypeInfo(
+          compDetailData.matchTypeDetails.gender,
+          compDetailData.matchTypeDetails.type,
+        )}
+        · {compDetailData.tier}
       </span>
     </div>
   );

--- a/components/organism/HomPage/HomeMyCompInfo/HomeMyCompInfo.tsx
+++ b/components/organism/HomPage/HomeMyCompInfo/HomeMyCompInfo.tsx
@@ -2,11 +2,11 @@ import { getMyCompData } from '@/app/_actions/getMyCompData';
 import { BEFORE, DURING, ENDED, MY_COMP_LIST } from '@/constants/competition';
 import Link from 'next/link';
 import React from 'react';
-import { MyCompData } from '@/@types/competition';
+import type { MyCompetition } from '@/@types/competition';
 import HomeMyCompInfoCard from '../HomeMyCompInfoCard/HomeMyCompInfoCard';
 
 const HomeMyCompInfo = async () => {
-  const [beforeData, duringData, endedData]: MyCompData[][] | { detail: string }[] =
+  const [beforeData, duringData, endedData]: MyCompetition[][] | { detail: string }[] =
     await Promise.all(
       [BEFORE, DURING, ENDED].map(async (status) => {
         return await getMyCompData({ status }, 4);

--- a/components/organism/HomPage/HomeMyCompInfoCard/HomeMyCompInfoCard.tsx
+++ b/components/organism/HomPage/HomeMyCompInfoCard/HomeMyCompInfoCard.tsx
@@ -1,11 +1,11 @@
-import type { MyCompData } from '@/@types/competition';
+import type { MyCompetition } from '@/@types/competition';
 import { cn } from '@/lib/utils/cn';
 import React from 'react';
 import { CompListVariants } from '../HomeCompInfo/HomeCompInfo';
 import CompCard from '@/components/module/CompCard/CompCard';
 
 interface HomeMyCompInfoCardProps {
-  data: MyCompData[] | { detail: string };
+  data: MyCompetition[] | { detail: string };
 }
 
 const HomeMyCompInfoCard = ({ data }: HomeMyCompInfoCardProps) => {

--- a/components/organism/MyPage/MyCompInfo/MyCompInfo.tsx
+++ b/components/organism/MyPage/MyCompInfo/MyCompInfo.tsx
@@ -2,11 +2,11 @@ import { getMyCompData } from '@/app/_actions/getMyCompData';
 import { cn } from '@/lib/utils/cn';
 import React from 'react';
 import { CompListVariants } from '../../HomPage/HomeCompInfo/HomeCompInfo';
-import type { MyCompData } from '@/@types/competition';
+import type { MyCompetition } from '@/@types/competition';
 import CompCard from '@/components/module/CompCard/CompCard';
 
 const MyCompInfo = async ({ status }: { status: string }) => {
-  const compData: MyCompData[] | { detail: string } = await getMyCompData({ status });
+  const compData: MyCompetition[] | { detail: string } = await getMyCompData({ status });
 
   return (
     <div

--- a/components/organism/MyPage/MyProfileCard/ProfileTab/ProfileTab.tsx
+++ b/components/organism/MyPage/MyProfileCard/ProfileTab/ProfileTab.tsx
@@ -5,6 +5,7 @@ import { MATCH_TYPE } from '@/constants/competition';
 import type { UserData } from '@/@types/user';
 import ChevronRightIcon from '@/app/_asset/icons/chevron-right.svg';
 import Link from 'next/link';
+import { MatchTypeKey } from '@/@types/competition';
 
 interface ProfileTabProps {
   userData: UserData;
@@ -50,8 +51,13 @@ const ProfileTab = ({ userData }: ProfileTabProps) => {
             <div>
               {tiers
                 .map(
-                  ({ name, matchTypeDetail }) =>
-                    `${MATCH_TYPE[matchTypeDetail.type]} ${name}`,
+                  ({
+                    name,
+                    matchTypeDetail,
+                  }: {
+                    name: string;
+                    matchTypeDetail: { type: MatchTypeKey };
+                  }) => `${MATCH_TYPE[matchTypeDetail.type]} ${name}`,
                 )
                 .join(' \u00B7 ')}
             </div>

--- a/components/organism/MyPage/RankingButton/RankingButton.tsx
+++ b/components/organism/MyPage/RankingButton/RankingButton.tsx
@@ -1,7 +1,8 @@
 import CheckIcon from '@/app/_asset/icons/check.svg';
 import type { RankingWithoutImage } from '@/@types/ranking';
-import { GENDER, MATCH_TYPE } from '@/constants/competition';
 import { cn } from '@/lib/utils/cn';
+import { GenderKey, MatchTypeKey } from '@/@types/competition';
+import { printMatchTypeInfo } from '@/lib/utils/printMatchTypeInfo';
 
 const RankingButton = ({
   rankingData,
@@ -12,8 +13,8 @@ const RankingButton = ({
 }: {
   rankingData: RankingWithoutImage[] | null;
   mainRanking: boolean;
-  gender: string;
-  type: string;
+  gender: GenderKey;
+  type: MatchTypeKey;
   isClicked: boolean;
 }) => {
   const assignTier = () => {
@@ -30,7 +31,7 @@ const RankingButton = ({
       )}
     >
       <div className="flex flex-col gap-[8px]">
-        {type === 'team' ? '팀 \u00B7 ' : `${GENDER[gender]} ${MATCH_TYPE[type]} \u00B7 `}
+        {type === 'team' ? '팀 \u00B7 ' : `${printMatchTypeInfo(gender, type)} \u00B7 `}
         {assignTier()}
         <div
           className={cn(

--- a/components/organism/MyPage/RankingButtonList/RankingButtonList.tsx
+++ b/components/organism/MyPage/RankingButtonList/RankingButtonList.tsx
@@ -5,12 +5,13 @@ import RankingButton from '../RankingButton/RankingButton';
 import { MyProfileRanking } from '@/@types/ranking';
 import Button from '@/components/core/Button/Button';
 import { useRouter } from 'next/navigation';
+import { GenderKey } from '@/@types/competition';
 
 const RankingButtonList = ({
   gender,
   myProfileRanking,
 }: {
-  gender: string;
+  gender: GenderKey;
   myProfileRanking: MyProfileRanking;
 }) => {
   const [pending, setPending] = useState(false);

--- a/components/organism/ProfilePage/ClubPage/InfoSection/InfoSection.tsx
+++ b/components/organism/ProfilePage/ClubPage/InfoSection/InfoSection.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import Image from 'next/image';
+import ClubIcon from '@/app/_asset/icons/group.svg';
 
 interface InfoSectionProps {
   name: string;
@@ -16,7 +17,9 @@ const InfoSection: FC<InfoSectionProps> = ({ name, description, imageUrl = null 
       </div>
       <div className="relative h-[80px] w-[80px] overflow-hidden rounded-[8px]">
         {imageUrl === null ? (
-          <div className="flex h-full w-full items-center justify-center bg-gray-30"></div>
+          <div className="flex h-full w-full items-center justify-center bg-gray-30">
+            <ClubIcon width={30} height={30} fill="#787878" />
+          </div>
         ) : (
           <Image
             src={imageUrl}

--- a/components/organism/ProfilePage/UserPage/RecordSection/RecordSectionHeader/RecordSectionHeader.tsx
+++ b/components/organism/ProfilePage/UserPage/RecordSection/RecordSectionHeader/RecordSectionHeader.tsx
@@ -1,11 +1,12 @@
-import { GENDER, MATCH_TYPE } from '@/constants/competition';
+import { MatchTypeDetails } from '@/@types/competition';
 import { formatDate } from '@/lib/utils/formatDate';
+import { printMatchTypeInfo } from '@/lib/utils/printMatchTypeInfo';
 import React, { FC } from 'react';
 
 interface RecordSectionHeaderProps {
   compName: string;
   date: string;
-  category: { gender: string; type: string };
+  category: MatchTypeDetails;
   tier: string;
 }
 
@@ -20,7 +21,7 @@ const RecordSectionHeader: FC<RecordSectionHeaderProps> = ({
       <div className="text-headline-5">{compName}</div>
       <div className="flex items-center gap-[4px] text-body-3 text-gray-60">
         <span>
-          {[formatDate(date), `${GENDER[gender]} ${MATCH_TYPE[type]}`, tier].join(
+          {[formatDate(date), `${printMatchTypeInfo(gender, type)}`, tier].join(
             ` \u00B7 `,
           )}
         </span>

--- a/components/organism/ProfilePage/UserPage/UserProfileRankingCard/UserProfileRankingCard.tsx
+++ b/components/organism/ProfilePage/UserPage/UserProfileRankingCard/UserProfileRankingCard.tsx
@@ -1,4 +1,5 @@
-import { MyProfileRanking, RankingWithoutImage } from '@/@types/ranking';
+import { MatchTypeKey } from '@/@types/competition';
+import { RankingWithoutImage } from '@/@types/ranking';
 import { MATCH_TYPE } from '@/constants/competition';
 import { cn } from '@/lib/utils/cn';
 import React from 'react';
@@ -9,7 +10,7 @@ const UserProfileRankingCard = ({
   isMain,
 }: {
   rankingData: RankingWithoutImage[] | null;
-  name: string;
+  name: MatchTypeKey;
   isMain: boolean;
 }) => {
   return (

--- a/constants/competition.ts
+++ b/constants/competition.ts
@@ -1,12 +1,16 @@
-import { CompCategory, CompStatusButtonContent } from '@/@types/competition';
+import {
+  CompCategory,
+  CompStatusButtonContentItem,
+  CompStatusButtonContentKey,
+} from '@/@types/competition';
 
-export const GENDER: { [key: string]: string } = {
+export const GENDER = {
   female: '여자',
   male: '남자',
   mix: '혼성',
 } as const;
 
-export const MATCH_TYPE: { [key: string]: string } = {
+export const MATCH_TYPE = {
   single: '단식',
   double: '복식',
   team: '팀',
@@ -58,7 +62,10 @@ export const COMP_DATA = {
   ],
 } as const;
 
-export const COMP_STATUS_BUTTON_CONTENT: CompStatusButtonContent = {
+export const COMP_STATUS_BUTTON_CONTENT: Record<
+  CompStatusButtonContentKey,
+  CompStatusButtonContentItem
+> = {
   'Registration Available': {
     label: '대회 신청하기',
     variant: 'primary',

--- a/lib/utils/filterCompetition.ts
+++ b/lib/utils/filterCompetition.ts
@@ -22,7 +22,7 @@ export const filterCompetition = ({
   };
 
   const setCategory = (comp: Competition): Competition => {
-    comp['category'] = category[comp.status];
+    comp['category'] = category[comp.status] as 'before' | 'during' | 'ended';
     return comp;
   };
 

--- a/lib/utils/printMatchTypeInfo.ts
+++ b/lib/utils/printMatchTypeInfo.ts
@@ -1,0 +1,9 @@
+import { GenderKey, MatchTypeKey } from '@/@types/competition';
+import { GENDER, MATCH_TYPE } from '@/constants/competition';
+
+export const printMatchTypeInfo = (
+  gender: GenderKey,
+  matchType: MatchTypeKey,
+): string => {
+  return `${GENDER[gender]} ${MATCH_TYPE[matchType]}`;
+};


### PR DESCRIPTION
- #186 

1. [x] api 연동
2. [x] 레이아웃 구현
3. [x] competition 타입 리팩토링
4. [x] 팀 랭킹 데이터 추가
5. [x] 참가 대기중 => 입금 대기중으로 멘트 변경